### PR TITLE
Improve Windows privilege detection and installer guidance

### DIFF
--- a/install-service/templates/install.ps1.js
+++ b/install-service/templates/install.ps1.js
@@ -189,7 +189,8 @@ elseif (-not $paramUserInstall -and -not (Test-Administrator)) {
     $userInstallPath = Join-Path $env:LOCALAPPDATA "Programs\cert-ctrl"
     Write-ErrorMessage "Administrator privileges are required to install to '$installPath'."
     Write-Info "Option 1: Close this window, re-launch Windows PowerShell or PowerShell with 'Run as administrator', then rerun install.ps1."
-    Write-Info "You can also specify -InstallDir to point at a directory you already own."
+    Write-Info "Option 2: Run the installer with -UserInstall for a per-user installation at '$userInstallPath'."
+    Write-Info "Option 3: Specify -InstallDir to point at a directory you already own."
     exit 1
 }
 


### PR DESCRIPTION
## Summary
- ensure the Windows CLI exits early with a clear administrator privilege warning when not elevated
- update the Windows PowerShell installer guidance to highlight the per-user installation option when elevation is missing

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917c616b2e083308c14f01bd1bd62e7)